### PR TITLE
Support non-github superdots plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ git clone https://github.com/super-dots/superdots ~/.superdots
 
 System functions that you will use with superdots are:
 
-| Command             | Example                        | Note                                       |
-|---------------------|--------------------------------|--------------------------------------------|
-| `superdots`         | `superdots a-user/a-superdots` | Records github.com/a-user/a-superdots      |
-| `superdots-install` | `superdots-install`            | Ensures all recorded plugins are installed |
-| `superdots-update`  | `superdots-update`             | Updates all recorded superdots plugins     |
+| Command             | Example                                      | Note                                       |
+|---------------------|----------------------------------------------|--------------------------------------------|
+| `superdots`         | `superdots a-user/a-superdots`               | Records github.com/a-user/a-superdots      |
+|                     | `superdots git@some.host:group/project.git`  |                                            |
+|                     | `superdots https://github.com/group/project` |                                            |
+| `superdots-install` | `superdots-install`                          | Ensures all recorded plugins are installed |
+| `superdots-update`  | `superdots-update`                           | Updates all recorded superdots plugins     |
 
 ## Efficiency Functions
 

--- a/dots/system/bash-sources/tmux.sh
+++ b/dots/system/bash-sources/tmux.sh
@@ -20,8 +20,11 @@ function _init_tmux_confs {
     # it needs to always exist
     touch "$SUPERDOTS_INTERMEDIATE_PATH"
 
+    superdots-debug "Initializing superdots combined tmux.conf at $SUPERDOTS_INTERMEDIATE_PATH"
+
     function _source_tmux_file {
         if [ ! -e "$1" ] ; then return ; fi
+        superdots-debug "    Sourcing tmux_init.conf at $1"
         echo "source $1" >> "$SUPERDOTS_INTERMEDIATE_PATH"
     }
 


### PR DESCRIPTION
This PR adds functionality to support non-github superdots plugins.

E.g. all below are now supported:

```
superdots d0c-s4vage/my-superdots
superdots https://d0c-s4vage/my-superdots
superdots git@github.com:d0c-s4vage/my-superdots.git
```