### PR TITLE
Hotfix/10 vim load order

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,3 +214,15 @@ slowly from:
 
 Superdots takes inspiration from vim's plugin structure, specifically
 [vim-plug](https://github.com/junegunn/vim-plug)'s approach to it.
+
+## Notes
+
+### Vim-Plug
+
+Be aware that vim-plug currently doesn't support multiple plugin sections. See
+
+* [vim-plug#300](https://github.com/junegunn/vim-plug/issues/300)
+* [vim-plug#615](https://github.com/junegunn/vim-plug/issues/615)
+
+The last superdots plugin loaded will have the final say on vim-plug
+definitions.

--- a/bash_init.sh
+++ b/bash_init.sh
@@ -31,7 +31,7 @@ SUPERDOTS_LOG='/tmp/superdots.log'
 SUPERDOTS_DEPS=(git)
 
 
-DOTS=()
+DOTS_LIST=()
 
 
 function superdots-echo {
@@ -163,7 +163,15 @@ function superdots-update-dot {
 # superdot super-dots/default-dots
 function superdots {
     superdots-debug "Recording $1 as superdot"
-    DOTS+=("$1")
+    DOTS_LIST+=("$1")
+
+    local dots=""
+    for dot_name in "${DOTS_LIST[@]}" ; do
+        if [ ! -z "$dots" ] ; then dots="$dots|" ; fi
+        dots="$dots$(superdots-localname "$dot_name")"
+    done
+    export DOTS="$dots"
+
     # load them as they're declared - if they exist
     superdots-source-dot "$1"
 }
@@ -175,9 +183,9 @@ function superdots-install {
         return 1
     fi
 
-    superdots-debug "Ensuring ${#DOTS[@]} superdots are installed"
+    superdots-debug "Ensuring ${#DOTS_LIST[@]} superdots are installed"
 
-    for dot in "${DOTS[@]}" ; do
+    for dot in "${DOTS_LIST[@]}" ; do
         superdots-fetch-dot "$dot"
         superdots-source-dot "$dot"
     done
@@ -192,7 +200,7 @@ function superdots-update {
 
     superdots-debug "Updating"
 
-    for dot in "${DOTS[@]}" ; do
+    for dot in "${DOTS_LIST[@]}" ; do
         superdots-update-dot "$dot"
         superdots-source-dot "$dot"
     done
@@ -200,7 +208,7 @@ function superdots-update {
 
 function superdots-init {
     # load system dots first, then plugins, then any local dots
-    for dot in system "${DOTS[@]}" local ; do
+    for dot in system "${DOTS_LIST[@]}" local ; do
         superdots-source-dot "$dot"
     done
 }

--- a/vim_init.vim
+++ b/vim_init.vim
@@ -9,15 +9,12 @@ function! s:source_dot(dot_dir)
 endfunction
 
 
-let s:vim_scripts_dirs = expand(s:this_dir."/dots/*")
+let s:vim_scripts_dir = expand(s:this_dir."/dots/")
 " source system first
 call s:source_dot(s:this_dir."/dots/system")
-for fdir in split(s:vim_scripts_dirs, '\n')
-    if fdir =~ "system$"
-        continue
-    elseif fdir =~ "local$"
-        continue
-    endif
+for fdir in split($DOTS, '|')
+    let fdir = s:vim_scripts_dir.fdir
     call s:source_dot(fdir)
 endfor
+" source local last
 call s:source_dot(s:this_dir."/dots/local")


### PR DESCRIPTION
Vim load order now uses "$DOTS" environment variable for determining what to load, and what order to load it in.

fixes #10 